### PR TITLE
Added support for date and date-time

### DIFF
--- a/packages/cli/src/core/ApiBase.ts
+++ b/packages/cli/src/core/ApiBase.ts
@@ -342,9 +342,21 @@ export class ApiBase {
                     this.appendTemp('z.number().int()');
                     break;
                 case SchemaType.STRING:
-                    this.appendTemp('z.string()');
-                    if (schema.maxLength !== undefined) {
-                        this.appendTemp(`.max(${schema.maxLength})`);
+                    switch (schema.format)
+                    {
+                        case 'date':
+                        case 'date-time':
+                            // TODO reference a shared type?
+                            this.appendTemp(
+                                'z.preprocess(arg => (typeof arg == "string" || arg instanceof Date ? new Date(arg) : undefined), z.date())');
+                            break;
+                        default:
+                            this.appendTemp('z.string()');
+                            if (schema.maxLength !== undefined) {
+                                this.appendTemp(`.max(${schema.maxLength})`);
+                            }
+
+                            break;
                     }
 
                     break;

--- a/packages/cli/src/core/ApiDescriptorBuilder.ts
+++ b/packages/cli/src/core/ApiDescriptorBuilder.ts
@@ -353,7 +353,8 @@ class ApiDescriptorBuilder {
                     };
                 case 'string':
                     return {
-                        type: SchemaType.STRING
+                        type: SchemaType.STRING,
+                        format: schema.format
                     };
                 case 'boolean':
                     return {

--- a/packages/cli/src/core/types/ApiDescriptor.ts
+++ b/packages/cli/src/core/types/ApiDescriptor.ts
@@ -108,6 +108,7 @@ export interface SchemaInteger extends SchemaBase {
 
 export interface SchemaString extends SchemaBase {
     type: SchemaType.STRING;
+    format?: string;
     maxLength?: number;
 }
 


### PR DESCRIPTION
I have added a simple date and date-time support. Unfortunately, I was not able to figure out how to properly add a shared type 

```
export const ParsedDate = z.preprocess(arg => (typeof arg == "string" || arg instanceof Date ? new Date(arg) : undefined), z.date());
```

So I have inlined the logic. (based on https://github.com/colinhacks/zod#dates) 

Could you please have a look? 
Because of that, I have not updated test snapshots. :-(
